### PR TITLE
fix(safeAreaTasks): add safe area on app and tasks vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/tasks.json
 .idea
 *.suo
 *.ntvs*

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,43 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"command": "npx",
+			"args": ["cap", "sync"],
+			"group": "build",
+			"label": "Capacitor: Sync",
+			"detail": "Copy web assets to native platforms and sync plugins",
+			"problemMatcher": []
+		},
+		{
+			"type": "shell",
+			"command": "npx",
+			"args": ["cap", "run", "android"],
+			"group": "test",
+			"label": "Capacitor: Run Android",
+			"detail": "Run the native app on Android",
+			"problemMatcher": []
+		},
+		{
+			"type": "shell",
+			"command": "npx",
+			"args": ["cap", "run", "ios"],
+			"group": "test",
+			"label": "Capacitor: Run iOS",
+			"detail": "Run the native app on iOS",
+			"problemMatcher": []
+		},
+		{
+			"type": "shell",
+			"command": "npm",
+			"args": ["run", "build"],
+			"group": "build",
+			"label": "Build and Sync",
+			"detail": "Build Vue app and sync with Capacitor",
+			"dependsOrder": "sequence",
+			"dependsOn": ["npm: build", "Capacitor: Sync"],
+			"problemMatcher": []
+		}
+	]
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>App de Rappel Mobilité</title>
   </head>
   <body>

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Capacitor (7.4.4):
+  - Capacitor (7.4.3):
     - CapacitorCordova
-  - CapacitorCordova (7.4.4)
+  - CapacitorCordova (7.4.3)
   - CapacitorLocalNotifications (7.0.3):
     - Capacitor
   - CapacitorSplashScreen (7.0.3):
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/splash-screen"
 
 SPEC CHECKSUMS:
-  Capacitor: 09d9ff8e9618e8c4b3cab2bbee34a17215dd2fef
-  CapacitorCordova: bf648a636f3c153f652d312ae145fb508b6ffced
+  Capacitor: b4741ca7affb32c1b70debd03df92cbf522d8a80
+  CapacitorCordova: 435121e81a2df4d0034f0fb11fcefab5104cfdb5
   CapacitorLocalNotifications: a57a6ff87c1f69a00598f9b97cf52eba8f9ff867
   CapacitorSplashScreen: d06ae8804808e9f649a08e7bb7f283c77b688084
 

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -7,6 +7,12 @@
   --bg-red-light: #f9f2f2;
   --accent-color: #f8002f;
   --content-color: #212121;
+
+  /* Safe area insets */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-inset-left: env(safe-area-inset-left, 0px);
+  --safe-area-inset-right: env(safe-area-inset-right, 0px);
 }
 
 /* semantic color variables for this project */
@@ -69,5 +75,11 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   width: 100vw;
+  margin: 0;
   padding: 24px;
+  /* Safe area adjustments */
+  padding-top: max(24px, env(safe-area-inset-top, 24px));
+  padding-left: max(24px, env(safe-area-inset-left, 24px));
+  padding-right: max(24px, env(safe-area-inset-right, 24px));
+  padding-bottom: 24px;
 }

--- a/src/components/bottom_sheet/BottomSheet.vue
+++ b/src/components/bottom_sheet/BottomSheet.vue
@@ -188,6 +188,9 @@ onUnmounted(() => {
   max-height: 50%;
   overflow-y: auto;
   padding: 20px;
+  padding-bottom: calc(20px + env(safe-area-inset-bottom, 34px));
+  padding-left: calc(20px + env(safe-area-inset-left, 0px));
+  padding-right: calc(20px + env(safe-area-inset-right, 0px));
 }
 
 .sheet-content {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -174,6 +174,10 @@ h2 {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding-top: 16px;
+  padding-bottom: calc(16px + env(safe-area-inset-bottom, 34px));
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 .overlay {


### PR DESCRIPTION
# 💡 Pull Request

## Describe the changes

This pull request introduces improvements for mobile device compatibility, particularly regarding safe area insets for modern devices (such as those with notches or rounded corners). It also adds new build and run tasks for Capacitor in the VSCode workspace to streamline development and testing on Android and iOS.
Added `.vscode/tasks.json` with tasks for syncing Capacitor, running the app on Android/iOS, and building/syncing the Vue app, making mobile development and testing more convenient.

## I want a manual testing of my code by reviewers
> If you select "No", you authorize reviewers to check your code without running the application

- [ ] Yes
- [X] No

### If yes, please describe how it can be tested:

1.
2.
3.

## Images, screenshots and videos
IOS And android: 
<img width="576" height="517" alt="image" src="https://github.com/user-attachments/assets/e66b9764-db84-4cfe-9aa0-eed89b3fb7af" />

Web view (nothing changed):
<img width="395" height="818" alt="image" src="https://github.com/user-attachments/assets/bc6e7c4f-10e1-4bcb-904e-902716651272" />


## I created tests (unit tests, integration tests...)

#### ℹ️ Write « N/A » if no testing is necessary

- [X] N/A

## Additional information

N/A
